### PR TITLE
Expand roadmap and examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 
-# Contributing to GPTInteract
+# Contributing to AI-For-Experts
 
-Thank you for considering contributing to **AI-For_Experts**! Contributions are welcome from the community, whether you're submitting bug reports, proposing new features, or helping to improve the documentation.
+Thank you for considering contributing to **AI-For-Experts**! Contributions are welcome from the community, whether you're submitting bug reports, proposing new features, or helping to improve the documentation.
 
 ## How to Contribute
 

--- a/README.md
+++ b/README.md
@@ -27,15 +27,24 @@ This repository explores the transformative potential of large language models (
     * [Environmental and Agricultural](#environmental-and-agricultural)
     * [Nonprofit and Social Services](#nonprofit-and-social-services)
 3. [Healthcare AI: An In-Depth Example](#healthcare-ai-an-in-depth-example)
-4. [Ethical Considerations and Responsible AI](#ethical-considerations-and-responsible-ai)
-5. [Contributing](#contributing)
-6. [License](#license)
+4. [Marketing AI: Practical Example](#marketing-ai-practical-example)
+5. [Ethical Considerations and Responsible AI](#ethical-considerations-and-responsible-ai)
+6. [Contributing](#contributing)
+7. [License](#license)
 
 ---
 
 ## Introduction
 
 Artificial intelligence (AI) is rapidly transforming various industries, and large language models (LLMs) are at the forefront of this revolution. LLMs are powerful AI systems that can understand and generate human-like text, making them invaluable tools for professionals across diverse fields. This repository explores the potential of LLMs to enhance productivity, creativity, and decision-making in a wide range of professions.
+
+---
+## Getting Started
+
+1. Clone or download this repository.
+2. Browse the README for prompt ideas and usage tips.
+3. Check the `examples/` folder for detailed walkthroughs.
+4. Contribute your own improvements via pull requests.
 
 ---
 
@@ -127,6 +136,9 @@ This section provides a comprehensive overview of how LLMs can be applied to dif
         * **Example Prompt:** "Based on this lead's website activity and email interactions, how likely are they to convert into a customer?"
     * **Sales Forecasting:** LLMs can analyze historical sales data and market trends to predict future sales, helping businesses plan inventory and allocate resources.
         * **Example Prompt:** "Forecast our sales for the next quarter based on previous sales data and current market conditions."
+    * **Ad Campaign Updates and Optimization:** LLMs can monitor advertising metrics and suggest improvements to ad copy, targeting, or budget allocation.
+        * **Example Prompt:** "Review our latest online ad campaign results and propose updated copy or audience targeting to improve click-through rates."
+        * **Further Guidance:** See our [Marketing AI examples](./examples/marketing-ai/) for additional prompt ideas.
 * **Business Analysts:**
     * **Data Analysis and Reporting:** LLMs can assist in analyzing business data, generating reports, and visualizing trends. 
         * **Example Prompt:** "Create a report summarizing our quarterly sales performance, including key metrics and insights."
@@ -613,6 +625,12 @@ Explore a detailed example of how LLMs are being applied to healthcare in our de
 
 ---
 
+## Marketing AI: Practical Example
+
+See the [Marketing AI](./examples/marketing-ai/) folder for prompts that help refine ad copy, target audiences, and experiment with new campaign ideas.
+
+---
+
 ## Ethical Considerations and Responsible AI
 
 
@@ -638,9 +656,13 @@ The use of LLMs in professional settings raises important ethical considerations
 
 ## Contributing
 
-## Contributing
-
 We welcome contributions from the community! Please see our [CONTRIBUTING.md](CONTRIBUTING.md) file for guidelines.
+
+---
+
+## Roadmap
+
+Our [ROADMAP.md](ROADMAP.md) outlines planned improvements, including new example templates and sample code for integrating LLMs.
 
 ---
 
@@ -650,13 +672,18 @@ We welcome contributions from the community! Please see our [CONTRIBUTING.md](CO
 
 
 
-**Repo Structure:**
 
+
+
+**Repo Structure:**
 
 AI-For-Experts/
 ├── README.md           # Main README for the repository
+├── ROADMAP.md          # Ideas for future improvements
 ├── CONTRIBUTING.md     # Guidelines for contributing to the project
 ├── LICENSE             # MIT License for the project
 └── examples/             # Folder for practical examples and in-depth case studies
-    └── healthcare-ai/    # Folder for your healthcare AI article
-        └── healthcare-prompt-engineering.md
+    ├── healthcare-ai/    # Folder for your healthcare AI article
+    │   └── healthcare-prompt-engineering.md
+    └── marketing-ai/     # Folder for marketing prompt strategies
+        └── ad-prompt-strategies.md

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,14 @@
+# Roadmap
+
+This project aims to showcase practical uses of large language models across many professions. Future improvements could include:
+
+- **Additional Examples:** Expand the `examples/` directory with more industry-specific guides.
+- **Tool Integrations:** Provide starter scripts demonstrating how to call LLM APIs from Python or other languages.
+- **Community Contributions:** Collect real-world case studies from users and highlight them in the README.
+- **Ethics Resources:** Curate links to best practices for responsible AI adoption in each field.
+- **Contribution Template:** Offer a standard template for new examples to ensure consistency across the repository.
+- **Sample Code:** Provide small scripts showing how to integrate LLM APIs or open-source models.
+- **Model Comparisons:** Evaluate popular open-source LLMs and document their strengths and limitations.
+- **Multilingual Docs:** Translate key documentation into other languages to reach a wider audience.
+
+These ideas help keep the documentation relevant and encourage contributions that push the repository forward.

--- a/examples/healthcare-ai/healthcare-prompt-engineering.md
+++ b/examples/healthcare-ai/healthcare-prompt-engineering.md
@@ -1,0 +1,13 @@
+# Healthcare Prompt Engineering
+
+This short example demonstrates how large language models can support healthcare professionals.
+
+## Patient Intake Automation
+- **Goal:** Quickly generate structured intake summaries from free-form notes.
+- **Prompt:** "Summarize the following patient notes and highlight any urgent issues: <notes>"
+
+## Treatment Plan Suggestions
+- **Goal:** Provide suggestions for treatment options based on patient history and guidelines.
+- **Prompt:** "Given this patient history, list potential treatment strategies and relevant clinical guidelines."
+
+These prompts illustrate how LLMs can streamline workflows and support decision-making in clinical settings.

--- a/examples/marketing-ai/ad-prompt-strategies.md
+++ b/examples/marketing-ai/ad-prompt-strategies.md
@@ -1,0 +1,17 @@
+# Marketing AI Prompt Strategies
+
+This example highlights how large language models can improve advertising effectiveness.
+
+## Refine Ad Copy
+- **Goal:** Craft persuasive messages that resonate with the target audience.
+- **Prompt:** "Rewrite this ad to better appeal to young professionals while keeping it under 50 words: <ad_text>"
+
+## Audience Segmentation
+- **Goal:** Identify specific customer segments for targeted outreach.
+- **Prompt:** "Based on this marketing data, suggest three distinct customer segments and the key message for each."
+
+## A/B Testing Ideas
+- **Goal:** Generate alternative headlines or visuals for testing.
+- **Prompt:** "Provide two alternative ad headlines and call-to-action phrases for A/B testing this campaign."
+
+These simple prompts show how marketers can leverage LLMs to iterate quickly and improve campaign performance.


### PR DESCRIPTION
## Summary
- expand `ROADMAP.md` with more improvement ideas
- add a Marketing AI example with ad prompt strategies
- reference the new example in the README and repo structure
- link to the roadmap from the documentation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841d84f06ec83209fed38f34da21623