### PR TITLE
Add marketing example and README link tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,11 @@ This repository explores the transformative potential of large language models (
     * [Environmental and Agricultural](#environmental-and-agricultural)
     * [Nonprofit and Social Services](#nonprofit-and-social-services)
 3. [Healthcare AI: An In-Depth Example](#healthcare-ai-an-in-depth-example)
-4. [Ethical Considerations and Responsible AI](#ethical-considerations-and-responsible-ai)
-5. [Contributing](#contributing)
-6. [License](#license)
+4. [Marketing AI: An In-Depth Example](#marketing-ai-an-in-depth-example)
+5. [Ethical Considerations and Responsible AI](#ethical-considerations-and-responsible-ai)
+6. [Contributing](#contributing)
+7. [License](#license)
+8. [Roadmap](ROADMAP.md)
 
 ---
 
@@ -623,6 +625,12 @@ Explore a detailed example of how LLMs are being applied to healthcare in our de
 
 ---
 
+## Marketing AI: An In-Depth Example
+
+For a focused look at how LLMs can accelerate marketing workflows, see the [Marketing AI](./examples/marketing-ai/) folder. It offers prompt strategies for audience research, campaign ideation, and content optimization.
+
+---
+
 ## Ethical Considerations and Responsible AI
 
 
@@ -656,6 +664,12 @@ We welcome contributions from the community! Please see our [CONTRIBUTING.md](CO
 
 [MIT License](LICENSE)
 
+---
+
+## Roadmap
+
+For planned improvements and future ideas, see the [Roadmap](ROADMAP.md).
+
 
 
 
@@ -669,5 +683,7 @@ AI-For-Experts/
 ├── CONTRIBUTING.md     # Guidelines for contributing to the project
 ├── LICENSE             # MIT License for the project
 └── examples/             # Folder for practical examples and in-depth case studies
-    └── healthcare-ai/    # Folder for your healthcare AI article
-        └── healthcare-prompt-engineering.md
+    ├── healthcare-ai/    # Folder for your healthcare AI article
+    │   └── healthcare-prompt-engineering.md
+    └── marketing-ai/     # Folder for marketing prompt strategies
+        └── marketing-prompt-strategies.md

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,5 +6,12 @@ This project aims to showcase practical uses of large language models across man
 - **Tool Integrations:** Provide starter scripts demonstrating how to call LLM APIs from Python or other languages.
 - **Community Contributions:** Collect real-world case studies from users and highlight them in the README.
 - **Ethics Resources:** Curate links to best practices for responsible AI adoption in each field.
+- **Marketing AI Example:** Create a concise guide showing how LLMs can support
+  campaign ideation, audience research, and content optimization. Link this
+  example from the README and expand the repository structure accordingly.
+- **Interactive Tutorials:** Explore notebook-based walkthroughs that let users
+  experiment with prompts and observe results directly.
+- **Automated Documentation Tests:** Add tests to ensure links remain valid and
+  referenced files exist.
 
 These ideas help keep the documentation relevant and encourage contributions that push the repository forward.

--- a/examples/marketing-ai/marketing-prompt-strategies.md
+++ b/examples/marketing-ai/marketing-prompt-strategies.md
@@ -1,0 +1,17 @@
+# Marketing Prompt Strategies
+
+This short example highlights how large language models can assist marketing professionals with effective prompts.
+
+## Audience Research
+- **Goal:** Discover potential customer segments and their needs.
+- **Prompt:** "Analyze this market data and identify key customer personas."
+
+## Campaign Ideation
+- **Goal:** Generate creative marketing campaign ideas.
+- **Prompt:** "Brainstorm three promotional campaign concepts for our new product launch."
+
+## Content Optimization
+- **Goal:** Improve the effectiveness of marketing copy.
+- **Prompt:** "Rewrite this landing page paragraph to increase conversion rates."
+
+These strategies demonstrate how LLMs can inspire marketing teams and streamline content creation.

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -1,0 +1,16 @@
+import os
+import re
+
+README = os.path.join(os.path.dirname(__file__), os.pardir, 'README.md')
+
+link_pattern = re.compile(r"\[[^\]]+\]\((./[^)]+)\)")
+
+
+def test_readme_links_exist():
+    with open(README, 'r', encoding='utf-8') as f:
+        content = f.read()
+    links = link_pattern.findall(content)
+    for link in links:
+        path = os.path.normpath(os.path.join(os.path.dirname(README), link))
+        assert os.path.exists(path), f"Missing file referenced in README: {link}"
+


### PR DESCRIPTION
## Summary
- create `marketing-ai` example directory and add prompt strategies
- expand the ROADMAP with marketing example and other ideas
- reference new marketing example in README and link to Roadmap
- update repository structure in README
- add tests checking that README links point to real files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841d84ef5b48320adf89c2fc5aeb4ea